### PR TITLE
remove hint of chapter 3.16 due to program update 851abd5

### DIFF
--- a/docu/3-advanced/5-subscribe-consumer-subaccount/README.md
+++ b/docu/3-advanced/5-subscribe-consumer-subaccount/README.md
@@ -98,8 +98,6 @@ Once the subscription of the SaaS application is successful and you created an A
 
 3.16. Once the Tenant administrator completed the registration, a success message is displayed and the page can be closed. 
 
-> **Hint** - Currently the automated redirect to the tenant specific application instance is not working and results in a 404 error. This issue is currently being analyzed. 
-
 [<img src="./images/IAS_RegSuccess.png" width="390" />](./images/IAS_RegSuccess.png?raw=true)
 
 3.17. Now the new **Tenant administrator** can log in to the consumer tenant instance using the new credentials.


### PR DESCRIPTION
Based on previous update 851abd5, I removed hint of chapter 3.16 in 3-advanced > 5-subscribe-consumer-subaccount.